### PR TITLE
Fix bug with variables Sentinel/msgtrace/ingestmsgtrace.ps1

### DIFF
--- a/Sentinel/msgtrace/ingestmsgtrace.ps1
+++ b/Sentinel/msgtrace/ingestmsgtrace.ps1
@@ -109,5 +109,5 @@ $storedTime = Get-content $Tracker
                                     }   
 
 #Update stored time and remove session
-out-file -FilePath $Tracker -NoNewline -InputObject (get-date $storedTime).AddMilliseconds(1).ToString("yyyy-MM-ddTHH:mm:ss.fffZ") 
+out-file -FilePath $Tracker -NoNewline -InputObject (get-date $startTime).AddMilliseconds(1).ToString("yyyy-MM-ddTHH:mm:ss.fffZ") 
 remove-PSSession $session                          


### PR DESCRIPTION
Wrong variable was used. $storedTime was called back into the get-date, making the next run only 1 millisecond later than the last. Should have been $startTime as that is the EndDate in the message trace.