### PR TITLE
Update run.ps1

### DIFF
--- a/Sentinel_Deployment/functionPackage/SyncDLPAnalyticsRules/run.ps1
+++ b/Sentinel_Deployment/functionPackage/SyncDLPAnalyticsRules/run.ps1
@@ -144,7 +144,10 @@ foreach ($workload in $workloads) {
     $csv = $response.Results 
 
     foreach ($item in $csv) {
-      if ($item.Name -notin $watchlist.results.SearchKey -and $item.Workload -notin $watchlist.results.Workload) {
+      <# commenting this out, this logic will only let you onboard policies from a workload one time. If you want to add policies to a workload the watchlist will not be updated and analytics rules wont fire
+      ($item.Name -notin $watchlist.results.SearchKey -and $item.Workload -notin $watchlist.results.Workload) #>
+      if ($item.Name -notin $watchlist.results.SearchKey) # this will ensure there are no duplicates while allowing inplace edits and updates. 
+      {
         $etag = New-Guid
         $a = @{
           'etag'       = $etag.guid


### PR DESCRIPTION
This came up in an escalation. I modified the if statement 

from:
'if ($item.Name -notin $watchlist.results.SearchKey -and $item.Workload -notin $watchlist.results.Workload)'

to:
'if ($item.Name -notin $watchlist.results.SearchKey)'

The reason for this change was the presence of the workload was preventing new analytics rules based on prior existing workloads to not run due to the watchlist lookup failing. We traced it back to this condition: "-and $item.Workload -notin $watchlist.results.Workload"